### PR TITLE
Support host builds for fbjni

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,20 @@ target_include_directories(fbjni PUBLIC
   cxx
 )
 
-target_link_libraries(fbjni
-  android
-  log
-)
+if (NOT ANDROID_ABI)
+  if (NOT JAVA_HOME)
+    message(FATAL_ERROR
+      "fbjni requires JAVA_HOME to be defined for non-Android builds.")
+  endif()
+  target_include_directories(fbjni PUBLIC ${JAVA_HOME}/include)
+  if (CMAKE_SYSTEM_NAME STREQUAL Linux)
+    target_include_directories(fbjni PUBLIC ${JAVA_HOME}/include/linux)
+  endif()
+endif()
+
+if (ANDROID_ABI)
+  target_link_libraries(fbjni
+    android
+    log
+  )
+endif()


### PR DESCRIPTION
Tested by running an Android build and a normal Java build on Linux.
Mac might need an additional include path.